### PR TITLE
Verify that priority is an integer in simulator

### DIFF
--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -177,6 +177,10 @@ export class Backend {
       throw new RangeError("matchValue must be a non-negative integer");
     }
 
+    if (!Number.isInteger(priority)) {
+      throw new RangeError("priority must be an integer");
+    }
+
     if (!this.enabled) {
       return {};
     }


### PR DESCRIPTION
The WebIDL definition guarantees this, but JavaScript and TypeScript do not.