### PR TITLE
Run tests on specific files, rather than directory

### DIFF
--- a/impl/package.json
+++ b/impl/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "tsc",
     "pack": "webpack --mode production",
-    "test": "node --test dist/",
+    "test": "node --test dist/**.test.js",
     "pretty": "prettier . --write",
     "pretty:check": "prettier . --check",
     "lint": "eslint src",


### PR DESCRIPTION
For compatibility with versions of node that don't operate on directories themselves.