### PR TITLE
How far back

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1295,8 +1295,9 @@ given [=site=] |site|,
 returning an [=epoch index=]:
 
 1.  Let |startEpoch| be a [=user agent=]-defined value
-    for the earliest [=epoch index=]
-    that is supported for attribution.
+    for the <dfn>earliest epoch index</a>,
+    which is the first [=epoch index=]
+    that is supported for attribution on |site|.
 
     <p class=note>
     This value is not a constant [=epoch index=].
@@ -1525,6 +1526,8 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
     :: |credit|
 1.  Let |lookback| be |options|.{{AttributionConversionOptions/lookbackDays}} [=days=]
     if it [=map/exists=], the [=implementation-defined=] maximum otherwise.
+1.  Let |lookback| be the [=implementation-defined=] maximum
+    if it is larger than that maximum.
 1.  If |lookback| is 0 [=days=], throw a {{RangeError}}.
 1.  If the [=list/size=] of
     |options|.{{AttributionConversionOptions/matchValues}} is
@@ -1768,6 +1771,33 @@ To <dfn>fill a histogram with last-n-touch attribution</dfn>, given a [=set=] of
 1.  Return |histogram|.
 
 </div>
+
+### Setting Implementation-Defined Values ### {#impl-def}
+
+This specification identifies several [=implementation-defined=] values.
+This section includes some recommendations for implementations
+regarding how to best set those values.
+
+An implementation sets [=implementation-defined=] maximum values
+for {{AttributionImpressionOptions/lifetimeDays}} and
+{{AttributionConversionOptions/lookbackDays}}.
+There is no point to having different maximum values for
+these values as the smaller of the two values
+will determine which saved [=impressions=] are available for conversions.
+
+An implementation can also use the value it sets
+for for {{AttributionImpressionOptions/lifetimeDays}} and
+{{AttributionConversionOptions/lookbackDays}}
+to set the [=earliest epoch index=]
+when executing the [=get the starting epoch for attribution=] algorithm.
+Invoking [=get the current epoch=] algorithm for the site,
+passing the current time less the corresponding duration
+ensures that the [=earliest epoch index=]
+includes all possible [=impressions=] that can be queried.
+
+Deciding on a value for differential privacy parameters
+is hard and therefore TBD.
+
 
 ## User Control and Visibility ## {#user-control}
 

--- a/api.bs
+++ b/api.bs
@@ -1289,20 +1289,21 @@ Resetting the budget is necessary to ensure
 that no information about the gap in browsing history
 is exposed.
 
-<div algorithm>
+<div algorithm="get the starting epoch for attribution">
 To <dfn>get the starting epoch for attribution</dfn>
 given [=site=] |site|,
 returning an [=epoch index=]:
 
 1.  Let |startEpoch| be a [=user agent=]-defined value
-    for the <dfn>earliest epoch index</a>,
+    for the <dfn>earliest epoch index</dfn>,
     which is the first [=epoch index=]
     that is supported for attribution on |site|.
 
     <p class=note>
     This value is not a constant [=epoch index=].
     A value is chosen for each site
-    based on [=user agent=] preferences or configuration.
+    based on [=user agent=] preferences or configuration;
+    see [[#impl-def]].
 
 1.  If the [=last browsing history clear=] is set,
     perform the following steps:
@@ -1772,7 +1773,7 @@ To <dfn>fill a histogram with last-n-touch attribution</dfn>, given a [=set=] of
 
 </div>
 
-### Setting Implementation-Defined Values ### {#impl-def}
+## Setting Implementation-Defined Values ## {#impl-def}
 
 This specification identifies several [=implementation-defined=] values.
 This section includes some recommendations for implementations

--- a/api.bs
+++ b/api.bs
@@ -1787,7 +1787,7 @@ these values as the smaller of the two values
 will determine which saved [=impressions=] are available for conversions.
 
 An implementation can also use the value it sets
-for for {{AttributionImpressionOptions/lifetimeDays}} and
+for {{AttributionImpressionOptions/lifetimeDays}} and
 {{AttributionConversionOptions/lookbackDays}}
 to set the [=earliest epoch index=]
 when executing the [=get the starting epoch for attribution=] algorithm.


### PR DESCRIPTION
This explains how at least a few of the easier implementation-defined values can be selected.  Or at least, explains the relationship between them.

It was enough text to justify having a section.  I didn't mark this as informative, though it is and it could be marked thus; I just generally hate the idea that you might mark something informative and then it no longer matters.  That's not how these things work.

There are more and we can continue to expand this section.  I added a TBD for epsilon, which is obviously very, very hard to decide on.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/pull/257.html" title="Last updated on Aug 22, 2025, 7:53 AM UTC (069423c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/257/4444705...069423c.html" title="Last updated on Aug 22, 2025, 7:53 AM UTC (069423c)">Diff</a>