### PR TITLE
Remove lookback-based early return from common matching logic

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1693,11 +1693,6 @@ To perform <dfn>common matching logic</dfn>, given
 
 1.  Let |matching| be an [=set/is empty|empty=] [=set=].
 
-1.  Let |earliestEpoch| be the result of calling [=get the current epoch=],
-    passing |topLevelSite| and (|now| − |options|' [=validated conversion options/lookback=]).
-
-1.  If |earliestEpoch| is greater than |epoch|, return |matching|.
-
 1.  [=set/iterate|For each=] |impression| in the [=impression store=]:
 
     1.  Let |impressionEpoch| be the result of calling [=get the current epoch=],

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -357,14 +357,6 @@ export class Backend {
   ): Set<Impression> {
     const matching = new Set<Impression>();
 
-    const earliestEpoch = this.#getCurrentEpoch(
-      topLevelSite,
-      now.subtract(lookback),
-    );
-    if (earliestEpoch > epoch) {
-      return matching;
-    }
-
     for (const impression of this.#impressions) {
       const impressionEpoch = this.#getCurrentEpoch(
         topLevelSite,


### PR DESCRIPTION
Fixes #232


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/260.html" title="Last updated on Aug 22, 2025, 12:26 PM UTC (48c86c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/260/85e2869...apasel422:48c86c8.html" title="Last updated on Aug 22, 2025, 12:26 PM UTC (48c86c8)">Diff</a>