### PR TITLE
Refactor privacy budget deduction

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1167,7 +1167,7 @@ nullable integer |l1Norm|:
 <p class=note>Single epoch attributions &mdash;
 the only case that |l1Norm| is non-null &mdash;
 do not cause any cascading effects across epochs.
-Attribution that involves multiple epochs consume double the budget
+Attribution that involves multiple epochs consumes double the budget
 because of the potential for one change to affect attribution across epochs.
 Doubling the deduction assumes that Laplace noise
 proportional to |maxValue| / |epsilon|

--- a/api.bs
+++ b/api.bs
@@ -1157,9 +1157,9 @@ nullable integer |l1Norm|:
 1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
     in the [=privacy budget store=].
 
-1.  Let |sensitivity| be |l1Norm| if |l1Norm| is non-null, |value| * 2 otherwise.
+1.  Let |sensitivity| be |l1Norm| if |l1Norm| is non-null, 2 * |value| otherwise.
 
-1.  Let |noiseScale| be |maxValue| / |epsilon|.
+1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
 
 1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
 

--- a/api.bs
+++ b/api.bs
@@ -1163,7 +1163,7 @@ nullable integer |l1Norm|:
 
 1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
 
-1.  Let |deductionFp| be |deductionFp| * 2 if |l1Norm| is null.
+1.  Set |deductionFp| to |deductionFp| * 2 if |l1Norm| is null.
 
 <p class=note>Single epoch attributions &mdash;
 the only case that |l1Norm| is non-null &mdash;

--- a/api.bs
+++ b/api.bs
@@ -1157,13 +1157,12 @@ nullable integer |l1Norm|:
 1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
     in the [=privacy budget store=].
 
-1.  Let |sensitivity| be |l1Norm| if |l1Norm| is non-null, |value| otherwise.
+1.  Let |sensitivity| be |l1Norm| if |l1Norm| is non-null, |value| * 2 otherwise.
 
 1.  Let |noiseScale| be |maxValue| / |epsilon|.
 
 1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
 
-1.  Set |deductionFp| to |deductionFp| * 2 if |l1Norm| is null.
 
 <p class=note>Single epoch attributions &mdash;
 the only case that |l1Norm| is non-null &mdash;

--- a/api.bs
+++ b/api.bs
@@ -1143,7 +1143,7 @@ given a [=privacy budget key=] |key|,
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|, and
-nullable integer |attributedValueForSingleEpochOpt|:
+nullable integer |l1Norm|:
 
 1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
     its value of |key| to be a [=user agent=]-defined value,
@@ -1157,17 +1157,22 @@ nullable integer |attributedValueForSingleEpochOpt|:
 1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
     in the [=privacy budget store=].
 
-1.  Let |singleEpochQuery| be true if |attributedValueForSingleEpochOpt| is non-null, false otherwise.
+1.  Let |sensitivity| be |l1Norm| if |l1Norm| is non-null, |value| otherwise.
 
-1.  Let |halfReportGlobalSensitivity| be |attributedValueForSingleEpochOpt|/2 if |singleEpochQuery| is true, |value| otherwise.
+1.  Let |noiseScale| be |maxValue| / |epsilon|.
 
-1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
+1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
 
-1.  Let |deductionFp| be |halfReportGlobalSensitivity| / |noiseScale|.
+1.  Let |deductionFp| be |deductionFp| * 2 if |l1Norm| is null.
 
-<p class=note>Single epoch attributions do not cause any cascading effects across epochs,
-so they do not need to consume double the budget. The deduction here is assuming Laplace
-noise is added to the histogram with scale param |maxValue| / |epsilon|.
+<p class=note>Single epoch attributions &mdash;
+the only case that |l1Norm| is non-null &mdash;
+do not cause any cascading effects across epochs.
+Attribution that involves multiple epochs consume double the budget
+because of the potential for one change to affect attribution across epochs.
+Doubling the deduction assumes that Laplace noise
+proportional to |maxValue| / |epsilon|
+is added to the aggregated histogram.
 
 1.  If |deductionFp| is negative or greater than [=maximum epsilon=],
     [=map/set|set=] the value of |key| in the [=privacy budget store=] to 0

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -528,8 +528,8 @@ export class Backend {
       };
       this.#privacyBudgetStore.push(entry);
     }
-    const sensitivity = l1Norm ?? (value * 2);
-    const noiseScale = maxValue / epsilon;
+    const sensitivity = l1Norm ?? (2 * value);
+    const noiseScale = 2 * maxValue / epsilon;
     const deductionFp = sensitivity / noiseScale;
     if (deductionFp < 0 || deductionFp > index.MAX_CONVERSION_EPSILON) {
       entry.value = 0;

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -528,12 +528,9 @@ export class Backend {
       };
       this.#privacyBudgetStore.push(entry);
     }
-    const sensitivity = l1Norm ?? value;
+    const sensitivity = l1Norm ?? (value * 2);
     const noiseScale = maxValue / epsilon;
-    let deductionFp = sensitivity / noiseScale;
-    if (l1Norm === null) {
-      deductionFp *= 2;
-    }
+    const deductionFp = sensitivity / noiseScale;
     if (deductionFp < 0 || deductionFp > index.MAX_CONVERSION_EPSILON) {
       entry.value = 0;
       return false;

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -454,7 +454,7 @@ export class Backend {
             options.epsilon,
             options.value,
             options.maxValue,
-            /*attributedValueForSingleEpochOpt=*/ null,
+            /*l1Norm=*/ null,
           );
           if (budgetOk) {
             for (const i of impressions) {

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -516,7 +516,7 @@ export class Backend {
     epsilon: number,
     value: number,
     maxValue: number,
-    attributedValueForSingleEpochOpt: number | null,
+    l1Norm: number | null,
   ): boolean {
     let entry = this.#privacyBudgetStore.find(
       (e) => e.epoch === key.epoch && e.site === key.site,
@@ -528,12 +528,12 @@ export class Backend {
       };
       this.#privacyBudgetStore.push(entry);
     }
-    const singleEpochQuery = attributedValueForSingleEpochOpt !== null;
-    const halfReportGlobalSensitivity = singleEpochQuery
-      ? attributedValueForSingleEpochOpt / 2
-      : value;
-    const noiseScale = (2 * maxValue) / epsilon;
-    const deductionFp = halfReportGlobalSensitivity / noiseScale;
+    const sensitivity = l1Norm ?? value;
+    const noiseScale = maxValue / epsilon;
+    let deductionFp = sensitivity / noiseScale;
+    if (l1Norm === null) {
+      deductionFp *= 2;
+    }
     if (deductionFp < 0 || deductionFp > index.MAX_CONVERSION_EPSILON) {
       entry.value = 0;
       return false;

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -528,8 +528,8 @@ export class Backend {
       };
       this.#privacyBudgetStore.push(entry);
     }
-    const sensitivity = l1Norm ?? (2 * value);
-    const noiseScale = 2 * maxValue / epsilon;
+    const sensitivity = l1Norm ?? 2 * value;
+    const noiseScale = (2 * maxValue) / epsilon;
     const deductionFp = sensitivity / noiseScale;
     if (deductionFp < 0 || deductionFp > index.MAX_CONVERSION_EPSILON) {
       entry.value = 0;


### PR DESCRIPTION
The whole business with halving and whatnot seemed overly complicated. This is simpler.  I know that this is probably abusing the definition of "sensitivity" and I could be convinced to care about a better name, but it is far easier to read this, I think.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/pull/264.html" title="Last updated on Sep 4, 2025, 10:47 PM UTC (d2bc089)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/264/934b12a...d2bc089.html" title="Last updated on Sep 4, 2025, 10:47 PM UTC (d2bc089)">Diff</a>