### PR TITLE
Extract single-epoch-vs-multi-epoch deduction computation

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1235,9 +1235,10 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
     wait until the value becomes false,
     then set the value to true.
 
+1.  Let |deduction| be |l1NormDeduction| if |isSingleEpoch| is true, |valueDeduction| otherwise.
+
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
-    with |key|, |l1NormDeduction|, |valueDeduction|,
-    |impressions|, and |isSingleEpoch|
+    with |key|, |deduction|, |valueDeduction|, and |impressions|
     is false, perform the following steps:
 
     1.  Set [=attribution budget lock=] to false.
@@ -1246,7 +1247,6 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
 1.  All budget checks passed, so perform the deductions:
 
-    1.  If |isSingleEpoch| let |deduction| be |l1NormDeduction| else let |deduction| be |valueDeduction|.
 
     1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
         in the [=privacy budget store=]
@@ -1291,11 +1291,9 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
 <div algorithm>
 To <dfn>check for available privacy budget</dfn>
-given a [=privacy budget key=] |key|, integer |l1NormDeduction|,
+given a [=privacy budget key=] |key|, integer |deduction|,
 integer |valueDeduction|,
-[=set=] of [=impressions=] |impressions| and boolean |isSingleEpoch|:
-
-1.  If |isSingleEpoch| let |deduction| be |l1NormDeduction| else let |deduction| be |valueDeduction|.
+and [=set=] of [=impressions=] |impressions|:
 
 1.  Let |currentValue| be set to the value of [=map/get|getting the value=] of |key|
     from [=privacy budget store=],

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -548,13 +548,13 @@ export class Backend {
     const valueDeductionFp = valueSensitivity / noiseScale;
     const l1NormDeduction = Math.ceil(l1NormDeductionFp * 1000000);
     const valueDeduction = Math.ceil(valueDeductionFp * 1000000);
+    const deduction = isSingleEpoch ? l1NormDeduction : valueDeduction;
     if (
       !this.#checkForAvailablePrivacyBudget(
         key,
-        l1NormDeduction,
+        deduction,
         valueDeduction,
         impressions,
-        isSingleEpoch,
       )
     ) {
       return false;
@@ -564,7 +564,6 @@ export class Backend {
       key,
       this.#delegate.perSitePrivacyBudget,
     );
-    const deduction = isSingleEpoch ? l1NormDeduction : valueDeduction;
     const currentValue = entry.value;
     entry.value = currentValue - deduction;
     const epoch = key.epoch;
@@ -593,12 +592,10 @@ export class Backend {
 
   #checkForAvailablePrivacyBudget(
     key: PrivacyBudgetKey,
-    l1NormDeduction: number,
+    deduction: number,
     valueDeduction: number,
     impressions: ReadonlySet<Impression>,
-    isSingleEpoch: boolean,
   ): boolean {
-    const deduction = isSingleEpoch ? l1NormDeduction : valueDeduction;
     const currentValue =
       getEntry(this.#privacyBudgetStore, key)?.value ??
       this.#delegate.perSitePrivacyBudget;


### PR DESCRIPTION
Part of #397.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/455.html" title="Last updated on Jul 7, 2026, 2:43 PM UTC (4ec3435)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/455/e3f147d...apasel422:4ec3435.html" title="Last updated on Jul 7, 2026, 2:43 PM UTC (4ec3435)">Diff</a>