### PR TITLE
Simplify cross-budget-deduction state tracking

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1205,8 +1205,7 @@ given a [=privacy budget key=] |key|,
 integer |value|,
 integer |maxValue|,
 boolean |isSingleEpoch|,
-integer |l1Norm|,
-and a [=set=] of [=privacy budget keys=] |deductedImpressionQuotas|:
+and an integer |l1Norm|:
 
 1.  Let |l1NormSensitivity| be |l1Norm| if |isSingleEpoch|, 2 * |value| otherwise.
 
@@ -1262,20 +1261,22 @@ and a [=set=] of [=privacy budget keys=] |deductedImpressionQuotas|:
         epoch because [=deduct privacy and safety budgets=] is called at most
         once per epoch.
 
+    1.  Let |deductedImpressionQuotas| be a new [=set=].
+
     1.  [=list/iterate|For each=] |impression| in |impressions|:
 
         1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
-
-        1.  Let |impressionQuotaKey| be an [=privacy budget key=]
-            whose items are |epoch| and |impressionSite|.
 
             <p class=note>The below ensures that we do not deduct budget
             more than once from the same impression site quota
             when there are multiple impressions for the site.
 
-        1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|:
+        1.  If |deductedImpressionQuotas| does not [=set/contain=] |impressionSite|:
 
-            1.  [=set/Append=] |deductedImpressionQuotas| with |impressionQuotaKey|.
+            1.  [=set/Append=] |impressionSite| to |deductedImpressionQuotas|.
+
+            1.  Let |impressionQuotaKey| be a [=privacy budget key=]
+                whose items are |epoch| and |impressionSite|.
 
             1.  Let |currentImpressionQuotaValue| be the result of [=map/get|getting the value=] of |impressionQuotaKey|
                 in the [=impression site quota per epoch=]
@@ -2059,8 +2060,6 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
     1.  [=Assert=]: |l1Norm| is less than or equal to |options|' [=validated conversion options/value=].
 
-1.  Let |deductedImpressionQuotas| be a new [=set=].
-
 1.  Let |matchedImpressions| be an [=set/is empty|empty=] [=set=].
 
 1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:
@@ -2080,7 +2079,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
             |options|' [=validated conversion options/epsilon=],
             |options|' [=validated conversion options/value=],
             |options|'s [=validated conversion options/max value=],
-            |isSingleEpoch|, |l1Norm|, and |deductedImpressionQuotas|.
+            |isSingleEpoch|, and |l1Norm|.
 
         1.  If |budgetAndSafetyOk| is true,
             [=set/extend=] |matchedImpressions| with |impressions|.

--- a/api.bs
+++ b/api.bs
@@ -1206,8 +1206,7 @@ integer |value|,
 integer |maxValue|,
 boolean |isSingleEpoch|,
 integer |l1Norm|,
-[=set=] of [=privacy budget keys=] |deductedImpressionQuotas|
-and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
+and a [=set=] of [=privacy budget keys=] |deductedImpressionQuotas|:
 
 1.  Let |l1NormSensitivity| be |l1Norm| if |isSingleEpoch|, 2 * |value| otherwise.
 
@@ -1257,9 +1256,11 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
     1.  Let |epoch| be the [=epoch index=] component of |key|.
 
-    1.  If |deductedGlobalBudgets| does not [=set/contain=] |epoch|,
-        [=set/append=] |deductedGlobalBudgets| with |epoch|
-        and decrement [=global privacy budget store=]\[|epoch|] by |valueDeduction|.
+    1.  Decrement [=global privacy budget store=]\[|epoch|] by |valueDeduction|.
+
+        <p class=note>This deduction is guaranteed to happen at most once per
+        epoch because [=deduct privacy and safety budgets=] is called at most
+        once per epoch.
 
     1.  [=list/iterate|For each=] |impression| in |impressions|:
 
@@ -2060,8 +2061,6 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
 1.  Let |deductedImpressionQuotas| be a new [=set=].
 
-1.  Let |deductedGlobalBudgets| be a new [=set=].
-
 1.  Let |matchedImpressions| be an [=set/is empty|empty=] [=set=].
 
 1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:
@@ -2081,7 +2080,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
             |options|' [=validated conversion options/epsilon=],
             |options|' [=validated conversion options/value=],
             |options|'s [=validated conversion options/max value=],
-            |isSingleEpoch|, |l1Norm|, |deductedImpressionQuotas|, and |deductedGlobalBudgets|.
+            |isSingleEpoch|, |l1Norm|, and |deductedImpressionQuotas|.
 
         1.  If |budgetAndSafetyOk| is true,
             [=set/extend=] |matchedImpressions| with |impressions|.

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -485,7 +485,6 @@ export class Backend {
 
     const matchedImpressions = new Set<Impression>();
     const deductedImpressionQuotas: PrivacyBudgetKey[] = [];
-    const deductedGlobalBudgets = new Set<number>();
 
     for (let epoch = startEpoch; epoch <= currentEpoch; ++epoch) {
       const impressions = this.#commonMatchingLogic(
@@ -506,7 +505,6 @@ export class Backend {
           isSingleEpoch,
           l1Norm,
           deductedImpressionQuotas,
-          deductedGlobalBudgets,
         );
         if (budgetAndSafetyOk) {
           for (const i of impressions) {
@@ -539,7 +537,6 @@ export class Backend {
     isSingleEpoch: boolean,
     l1Norm: number,
     deductedImpressionQuotas: PrivacyBudgetKey[],
-    deductedGlobalBudgets: Set<number>,
   ): boolean {
     const l1NormSensitivity = isSingleEpoch ? l1Norm : 2 * value;
     const valueSensitivity = 2 * value;
@@ -567,8 +564,7 @@ export class Backend {
     const currentValue = entry.value;
     entry.value = currentValue - deduction;
     const epoch = key.epoch;
-    if (!deductedGlobalBudgets.has(epoch)) {
-      deductedGlobalBudgets.add(epoch);
+    {
       const value = this.#globalPrivacyBudgetStore.get(epoch)!;
       this.#globalPrivacyBudgetStore.set(epoch, value - valueDeduction);
     }

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -484,7 +484,6 @@ export class Backend {
     }
 
     const matchedImpressions = new Set<Impression>();
-    const deductedImpressionQuotas: PrivacyBudgetKey[] = [];
 
     for (let epoch = startEpoch; epoch <= currentEpoch; ++epoch) {
       const impressions = this.#commonMatchingLogic(
@@ -504,7 +503,6 @@ export class Backend {
           options.maxValue,
           isSingleEpoch,
           l1Norm,
-          deductedImpressionQuotas,
         );
         if (budgetAndSafetyOk) {
           for (const i of impressions) {
@@ -536,7 +534,6 @@ export class Backend {
     maxValue: number,
     isSingleEpoch: boolean,
     l1Norm: number,
-    deductedImpressionQuotas: PrivacyBudgetKey[],
   ): boolean {
     const l1NormSensitivity = isSingleEpoch ? l1Norm : 2 * value;
     const valueSensitivity = 2 * value;
@@ -568,6 +565,7 @@ export class Backend {
       const value = this.#globalPrivacyBudgetStore.get(epoch)!;
       this.#globalPrivacyBudgetStore.set(epoch, value - valueDeduction);
     }
+    const deductedImpressionQuotas = new Set<string>();
     for (const impression of impressions) {
       const impressionSite = impression.impressionSite;
       const impressionQuotaKey = { site: impressionSite, epoch };
@@ -576,10 +574,9 @@ export class Backend {
         impressionQuotaKey,
         this.#delegate.impressionSiteQuotaPerEpoch,
       );
-      if (
-        getEntry(deductedImpressionQuotas, impressionQuotaKey) === undefined
-      ) {
-        deductedImpressionQuotas.push(impressionQuotaKey);
+      const sizeBefore = deductedImpressionQuotas.size;
+      deductedImpressionQuotas.add(impression.impressionSite);
+      if (sizeBefore != deductedImpressionQuotas.size) {
         entryI.value -= valueDeduction;
       }
     }


### PR DESCRIPTION
The "deduct privacy and safety budgets" algorithm is invoked exactly once per epoch in the chosen range, so it is unconditionally true that each epoch's global budget is deducted from at most once.

Similarly, a given impression belongs to a single epoch, so there is no need to maintain a set keyed by epoch across invocations of that algorithm: We only need to remember whether a given impression *site* has already had its quota modified in the current epoch.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/458.html" title="Last updated on Jul 13, 2026, 5:11 PM UTC (50c1dbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/458/a761634...apasel422:50c1dbd.html" title="Last updated on Jul 13, 2026, 5:11 PM UTC (50c1dbd)">Diff</a>