### PR TITLE
Cleanly split single-epoch and multi-epoch attribution handling

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1204,16 +1204,11 @@ given a [=privacy budget key=] |key|,
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|,
-boolean |isSingleEpoch|,
-and an integer |l1Norm|:
-
-1.  Let |l1NormSensitivity| be |l1Norm| if |isSingleEpoch|, 2 * |value| otherwise.
+and an integer or null |singleEpochL1Norm|:
 
 1.  Let |valueSensitivity| be 2 * |value|.
 
 1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
-
-1.  Let |l1NormDeductionFp| be |l1NormSensitivity| / |noiseScale|.
 
 1.  Let |valueDeductionFp| be |valueSensitivity| / |noiseScale|.
 
@@ -1225,15 +1220,21 @@ and an integer |l1Norm|:
     proportional to |maxValue| / |epsilon|
     is added to the aggregated histogram.
 
-1.  Let |l1NormDeduction| be |l1NormDeductionFp| * 1000000, rounded towards positive Infinity.
-
 1.  Let |valueDeduction| be |valueDeductionFp| * 1000000, rounded towards positive Infinity.
+
+1.  Let |deduction| be |valueDeduction|.
+
+1.  If |singleEpochL1Norm| is not null:
+
+    1.  Let |l1NormDeductionFp| be |singleEpochL1Norm| / |noiseScale|.
+
+    1.  Let |l1NormDeduction| be |l1NormDeductionFp| * 1000000, rounded towards positive Infinity.
+
+    1.  Set |deduction| to |l1NormDeduction|.
 
 1.  If [=attribution budget lock=] is true,
     wait until the value becomes false,
     then set the value to true.
-
-1.  Let |deduction| be |l1NormDeduction| if |isSingleEpoch| is true, |valueDeduction| otherwise.
 
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
     with |key|, |deduction|, |valueDeduction|, and |impressions|
@@ -2044,8 +2045,6 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
 1.  Let |isSingleEpoch| be true if |currentEpoch| is equal to |earliestEpoch|, false otherwise.
 
-1.  Let |l1Norm| be 0.
-
 1.  If |isSingleEpoch| is true:
     1.  Let |impressions| be the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |currentEpoch|, and |now|.
@@ -2059,9 +2058,23 @@ To <dfn>do attribution and fill a histogram</dfn>, given
         |options|' [=validated conversion options/value=], and
         |options|' [=validated conversion options/credit=].
 
-    1.  Set |l1Norm| to the sum of the [=list/items=] in |histogram|.
+    1.  Let |l1Norm| be the sum of the [=list/items=] in |histogram|.
 
     1.  [=Assert=]: |l1Norm| is less than or equal to |options|' [=validated conversion options/value=].
+
+    1.  Let |key| be a [=privacy budget key=] whose items are |currentEpoch| and |topLevelSite|.
+
+    1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
+        with |key|, |impressions|,
+        |options|' [=validated conversion options/epsilon=],
+        |options|' [=validated conversion options/value=],
+        |options|'s [=validated conversion options/max value=],
+        and |l1Norm|.
+
+    1.  If |budgetAndSafetyOk| is true, return |histogram|.
+
+    1.  Return the result of invoking [=create an all-zero histogram=] with
+        |options|' [=validated conversion options/histogram size=].
 
 1.  Let |matchedImpressions| be an [=set/is empty|empty=] [=set=].
 
@@ -2069,9 +2082,6 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
     1.  Let |impressions| be the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |epoch|, and |now|.
-
-        <p class=note>In the single-epoch case, this is recomputing |matchedImpressions|.
-        Implementations will want to avoid doing that work twice.
 
     1.  If |impressions| [=set/is empty|is not empty=]:
 
@@ -2082,7 +2092,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
             |options|' [=validated conversion options/epsilon=],
             |options|' [=validated conversion options/value=],
             |options|'s [=validated conversion options/max value=],
-            |isSingleEpoch|, and |l1Norm|.
+            and null.
 
         1.  If |budgetAndSafetyOk| is true,
             [=set/extend=] |matchedImpressions| with |impressions|.

--- a/api.bs
+++ b/api.bs
@@ -1216,14 +1216,6 @@ and an optional integer |singleEpochL1Norm|:
 
 1.  Let |valueDeductionFp| be |valueSensitivity| / |noiseScale|.
 
-    <p class=note>Single-epoch attributions
-    do not cause any cascading effects across epochs.
-    Attribution that involves multiple epochs consumes double the budget
-    because of the potential for one change to affect attribution across epochs.
-    Doubling the deduction assumes that Laplace noise
-    proportional to |maxValue| / |epsilon|
-    is added to the aggregated histogram.
-
 1.  Let |valueDeduction| be |valueDeductionFp| * 1000000, rounded towards positive Infinity.
 
 1.  Let |deduction| be |valueDeduction|.
@@ -1235,6 +1227,14 @@ and an optional integer |singleEpochL1Norm|:
     1.  Let |l1NormDeduction| be |l1NormDeductionFp| * 1000000, rounded towards positive Infinity.
 
     1.  Set |deduction| to |l1NormDeduction|.
+
+    <p class=note>Single-epoch attributions
+    do not cause any cascading effects across epochs.
+    Attribution that involves multiple epochs consumes double the budget
+    because of the potential for one change to affect attribution across epochs.
+    Doubling the deduction assumes that Laplace noise
+    proportional to |maxValue| / |epsilon|
+    is added to the aggregated histogram.
 
 1.  If [=attribution budget lock=] is true,
     wait until the value becomes false,

--- a/api.bs
+++ b/api.bs
@@ -1201,10 +1201,14 @@ that could be maliciously triggered.
 To <dfn>deduct privacy and safety budgets</dfn>
 given a [=privacy budget key=] |key|,
 [=set=] of [=impressions=] |impressions|,
-[[WEBIDL#idl-double|double]] |epsilon|,
-integer |value|,
-integer |maxValue|,
-and an integer or null |singleEpochL1Norm|:
+[=validated conversion options=] |options|,
+and an optional integer |singleEpochL1Norm|:
+
+1.  Let |epsilon| be |options|'s [=validated conversion options/epsilon=].
+
+1.  Let |value| be |options|'s [=validated conversion options/value=].
+
+1.  Let |maxValue| be |options|'s [=validated conversion options/max value=].
 
 1.  Let |valueSensitivity| be 2 * |value|.
 
@@ -1224,7 +1228,7 @@ and an integer or null |singleEpochL1Norm|:
 
 1.  Let |deduction| be |valueDeduction|.
 
-1.  If |singleEpochL1Norm| is not null:
+1.  If |singleEpochL1Norm| was given:
 
     1.  Let |l1NormDeductionFp| be |singleEpochL1Norm| / |noiseScale|.
 
@@ -2065,11 +2069,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
     1.  Let |key| be a [=privacy budget key=] whose items are |currentEpoch| and |topLevelSite|.
 
     1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
-        with |key|, |impressions|,
-        |options|' [=validated conversion options/epsilon=],
-        |options|' [=validated conversion options/value=],
-        |options|'s [=validated conversion options/max value=],
-        and |l1Norm|.
+        with |key|, |impressions|, |options|, and |l1Norm|.
 
     1.  If |budgetAndSafetyOk| is true, return |histogram|.
 
@@ -2088,11 +2088,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
         1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
 
         1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
-            with |key|, |impressions|,
-            |options|' [=validated conversion options/epsilon=],
-            |options|' [=validated conversion options/value=],
-            |options|'s [=validated conversion options/max value=],
-            and null.
+            with |key|, |impressions|, and |options|.
 
         1.  If |budgetAndSafetyOk| is true,
             [=set/extend=] |matchedImpressions| with |impressions|.

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -460,7 +460,6 @@ export class Backend {
     const startEpoch = this.#getStartEpoch(now);
     const earliestEpoch = this.#getCurrentEpoch(now.subtract(options.lookback));
     const isSingleEpoch = currentEpoch === earliestEpoch;
-    let l1Norm = 0;
 
     if (isSingleEpoch) {
       const impressions = this.#commonMatchingLogic(
@@ -479,8 +478,21 @@ export class Backend {
         options.value,
         options.credit,
       );
-      l1Norm = histogram.reduce((a, b) => a + b, 0);
+      const l1Norm = histogram.reduce((a, b) => a + b, 0);
       assert(l1Norm <= options.value);
+
+      const key = { epoch: currentEpoch, site: topLevelSite };
+      const budgetAndSafetyOk = this.#deductPrivacyAndSafetyBudgets(
+        key,
+        impressions,
+        options.epsilon,
+        options.value,
+        options.maxValue,
+        l1Norm,
+      );
+      return budgetAndSafetyOk
+        ? histogram
+        : allZeroHistogram(options.histogramSize);
     }
 
     const matchedImpressions = new Set<Impression>();
@@ -501,8 +513,7 @@ export class Backend {
           options.epsilon,
           options.value,
           options.maxValue,
-          isSingleEpoch,
-          l1Norm,
+          /*singleEpochL1Norm=*/ null,
         );
         if (budgetAndSafetyOk) {
           for (const i of impressions) {
@@ -532,17 +543,18 @@ export class Backend {
     epsilon: number,
     value: number,
     maxValue: number,
-    isSingleEpoch: boolean,
-    l1Norm: number,
+    singleEpochL1Norm: number | null,
   ): boolean {
-    const l1NormSensitivity = isSingleEpoch ? l1Norm : 2 * value;
     const valueSensitivity = 2 * value;
     const noiseScale = (2 * maxValue) / epsilon;
-    const l1NormDeductionFp = l1NormSensitivity / noiseScale;
     const valueDeductionFp = valueSensitivity / noiseScale;
-    const l1NormDeduction = Math.ceil(l1NormDeductionFp * 1000000);
     const valueDeduction = Math.ceil(valueDeductionFp * 1000000);
-    const deduction = isSingleEpoch ? l1NormDeduction : valueDeduction;
+
+    const deduction =
+      singleEpochL1Norm === null
+        ? valueDeduction
+        : Math.ceil((singleEpochL1Norm / noiseScale) * 1000000);
+
     if (
       !this.#checkForAvailablePrivacyBudget(
         key,


### PR DESCRIPTION
This makes it clear that the L1 norm computation is irrelevant for the latter, and inherently avoids the redundant common matching logic and histogram creation for the former.

Fixes #397.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/461.html" title="Last updated on Jul 30, 2026, 3:21 PM UTC (2926c2f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/461/3362d5c...apasel422:2926c2f.html" title="Last updated on Jul 30, 2026, 3:21 PM UTC (2926c2f)">Diff</a>