### PR TITLE
Remove erroneous assumption that a key exists in global privacy budget store

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1255,7 +1255,12 @@ and an integer |l1Norm|:
 
     1.  Let |epoch| be the [=epoch index=] component of |key|.
 
-    1.  Decrement [=global privacy budget store=]\[|epoch|] by |valueDeduction|.
+    1.  Let |currentGlobalValue| be the result of [=map/get|getting the value=]
+        of |epoch| in the [=global privacy budget store=]
+        with a default of the [=global privacy budget per epoch=].
+
+    1.  [=map/set|Set=] the value of |epoch| in the [=global privacy budget store=]
+        to |currentGlobalValue| − |valueDeduction|.
 
         <p class=note>This deduction is guaranteed to happen at most once per
         epoch because [=deduct privacy and safety budgets=] is called at most

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -562,8 +562,14 @@ export class Backend {
     entry.value = currentValue - deduction;
     const epoch = key.epoch;
     {
-      const value = this.#globalPrivacyBudgetStore.get(epoch)!;
-      this.#globalPrivacyBudgetStore.set(epoch, value - valueDeduction);
+      const currentGlobalValue =
+        this.#globalPrivacyBudgetStore.get(epoch) ??
+        this.#delegate.globalPrivacyBudgetPerEpoch;
+
+      this.#globalPrivacyBudgetStore.set(
+        epoch,
+        currentGlobalValue - valueDeduction,
+      );
     }
     const deductedImpressionQuotas = new Set<string>();
     for (const impression of impressions) {


### PR DESCRIPTION
In the specification, the global privacy budget store was only written to during the deduction, but the first time the epoch's global budget is ever modified, the key doesn't exist, so it must be initialized.

In the simulator, Map.get returns undefined, which is coerced into NaN as a result of the subtraction, causing NaN to be written into the map during the subsequent Map.set call. Later global budget checks for the same epoch would succeed because `valueDeduction > currentGlobalValue` returns false when currentGlobalValue is NaN. Rewriting that check as `!(valueDeduction <= currentGlobalValue)` correctly causes the tests to fail without the fix in this commit.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/466.html" title="Last updated on Jul 15, 2026, 2:26 PM UTC (f8965f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/466/3c1615c...apasel422:f8965f7.html" title="Last updated on Jul 15, 2026, 2:26 PM UTC (f8965f7)">Diff</a>