### PR TITLE
Surface errors when clearing an empty site set

### DIFF
--- a/impl/index.html
+++ b/impl/index.html
@@ -139,6 +139,7 @@
             >
             <button>Clear Site Data as User</button>
           </line>
+          <output aria-live="polite"></output>
         </form>
         <form id="clear-as-site" class="simple">
           <line>

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -743,6 +743,11 @@ export class Backend {
   clearState(sites: readonly string[], forgetVisits: boolean): void {
     const parsedSites = parseSites(sites, "sites", Infinity);
     if (!forgetVisits) {
+      if (parsedSites.size === 0) {
+        throw new RangeError(
+          "sites must not be empty unless visits are forgotten",
+        );
+      }
       this.#zeroBudgetForSites(parsedSites);
       return;
     }

--- a/impl/src/clear.test.ts
+++ b/impl/src/clear.test.ts
@@ -42,7 +42,10 @@ void test("clear-site-state", () => {
   const backend = setupImpressions();
 
   // Check that this rejects correctly.
-  assert.throws(() => backend.clearState([], false));
+  assert.throws(() => backend.clearState([], false), {
+    name: "RangeError",
+    message: "sites must not be empty unless visits are forgotten",
+  });
 
   // Run one query with the affected site.
   const before = backend.measureConversion("conv-one.example", undefined, {

--- a/impl/src/simulator.ts
+++ b/impl/src/simulator.ts
@@ -149,6 +149,9 @@ function updateBudgetAndEpochTables() {
 }
 
 {
+  const form = document.querySelector<HTMLFormElement>("#clear-as-user")!;
+  const output = form.querySelector<HTMLOutputElement>("output")!;
+
   function updateLastClear() {
     updateImpressionsTable();
     updateBudgetAndEpochTables();
@@ -161,18 +164,22 @@ function updateBudgetAndEpochTables() {
     }
   }
 
-  document
-    .querySelector<HTMLFormElement>("#clear-as-user")!
-    .addEventListener("submit", function (this: HTMLFormElement, e) {
-      e.preventDefault();
+  form.addEventListener("submit", function (this: HTMLFormElement, e) {
+    e.preventDefault();
 
-      const sites = this.elements.namedItem("sites") as HTMLInputElement;
-      const forgetVisits = this.elements.namedItem(
-        "forget-visits",
-      ) as HTMLInputElement;
+    const sites = this.elements.namedItem("sites") as HTMLInputElement;
+    const forgetVisits = this.elements.namedItem(
+      "forget-visits",
+    ) as HTMLInputElement;
+    try {
       backend.clearState(spaceSeparated(sites), forgetVisits.checked);
+      output.innerText = "Success";
       updateLastClear();
-    });
+    } catch (e) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      output.innerText = `Error: ${e}`;
+    }
+  });
 
   document
     .querySelector<HTMLFormElement>("#clear-as-site")!


### PR DESCRIPTION
Fixes #293.

## What changed

- replace the generic assertion for an empty site set with a descriptive `RangeError`
- catch clear-state failures in the simulator and show the result in an accessible live output
- add regression coverage for the error type and message

## Why

Clearing site state with no sites and without selecting **Forget Visits** is invalid, but the exception previously escaped the submit handler. The operation appeared to do nothing and gave the user no explanation.

An empty site set remains valid when **Forget Visits** is selected because that operation intentionally clears all visits.

## Validation

- `npm run build`
- `npm test` — 126 tests passed
- `npm run lint`
- `npm run pretty:check`
- `npm run pack`
- headless Chrome submission of the affected form, confirming the descriptive error appears in the live output

AI assistance disclosure: Codex assisted with investigation, implementation, and testing. I reviewed and verified the changes.
