### PR TITLE
Remove redundant finite check for credit values

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1961,9 +1961,7 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
     throw a {{RangeError}}.
 1.  Let |credit| be |options|.{{AttributionConversionOptions/credit}} if it [=map/exists=], «1» otherwise.
 1.  If |credit| [=list/is empty=], throw a {{RangeError}}.
-1.  If any of the [=list/items=] of |credit| are
-    not [finite](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.isfinite)
-    or less than or equal to 0,
+1.  If any of the [=list/items=] of |credit| are less than or equal to 0,
     throw a {{RangeError}}.
 1.  If the [=list/size=] of |credit| exceeds the [=implementation-defined=]
     [=maximum number of credit values=], throw a {{RangeError}}.


### PR DESCRIPTION
The `AttributionConversionOptions.credit` field is defined as a `sequence<double>`, which is already guaranteed to be finite per WebIDL.

The equivalent check is already properly represented as an assertion in the simulator.

https://webidl.spec.whatwg.org/#idl-double


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/470.html" title="Last updated on Jul 16, 2026, 2:32 PM UTC (0cdcec1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/470/3c1615c...apasel422:0cdcec1.html" title="Last updated on Jul 16, 2026, 2:32 PM UTC (0cdcec1)">Diff</a>