### PR TITLE
Lift epoch computation out of loop in budget-zeroing algorithm

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1666,15 +1666,15 @@ and a [=moment=] |now|:
 
     1.  [=Assert=]: |sites| [=set/is empty|is not empty=].
 
+    1.  Let |startingEpoch| be the result of
+        invoking [=get the starting epoch for attribution=]
+        given |now|.
+
+    1.  Let |currentEpoch| be the result of
+        invoking [=get the current epoch=]
+        given |now|.
+
     1.  [=set/iterate|For each=] |site| in |sites|:
-
-        1.  Let |startingEpoch| be the result of
-            invoking [=get the starting epoch for attribution=]
-            given |now|.
-
-        1.  Let |currentEpoch| be the result of
-            invoking [=get the current epoch=]
-            given |now|.
 
         1.  [=set/iterate|For each=] |epoch| in [=the inclusive range=]
             from |startingEpoch| to |currentEpoch|:

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -725,10 +725,10 @@ export class Backend {
     assert(sites.size > 0);
 
     const now = this.#delegate.now();
+    const startEpoch = this.#getStartEpoch(now);
+    const currentEpoch = this.#getCurrentEpoch(now);
 
     for (const site of sites) {
-      const startEpoch = this.#getStartEpoch(now);
-      const currentEpoch = this.#getCurrentEpoch(now);
       for (let epoch = startEpoch; epoch <= currentEpoch; ++epoch) {
         const entry = getOrInsertEntry(
           this.#privacyBudgetStore,


### PR DESCRIPTION
To make it clear that the epoch indices do not vary by site.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/471.html" title="Last updated on Jul 17, 2026, 3:23 PM UTC (5d2b5e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/471/de9139c...apasel422:5d2b5e8.html" title="Last updated on Jul 17, 2026, 3:23 PM UTC (5d2b5e8)">Diff</a>