### PR TITLE
Deal with localhost on implicit values

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1738,7 +1738,8 @@ and a [=moment=] |now|:
 <div algorithm>
 The <dfn method for=Attribution>saveImpression(|options|)</dfn> method steps are:
 
-1.  Let |implicitInputs| be the result of [=obtaining the implicit API inputs=] from [=this=].
+1.  Let |implicitInputs| be the result of [=obtaining the implicit API inputs=] from [=this=],
+    returning [=a promise rejected with=] any thrown reason.
 1.  [=Assert=]: |implicitInputs| is not null.
 1.  Return the result of running [=save an impression=] with |options| and |implicitInputs|.
 
@@ -1889,7 +1890,8 @@ asynchronously, queuing work on the <dfn>Attribution [=task source=]</dfn>.
 <div algorithm>
 The <dfn method for=Attribution>measureConversion(|options|)</dfn> method steps are:
 
-1.  Let |implicitInputs| be the result of [=obtaining the implicit API inputs=] from [=this=].
+1.  Let |implicitInputs| be the result of [=obtaining the implicit API inputs=] from [=this=],
+    returning [=a promise rejected with=] any thrown reason.
 1.  [=Assert=]: |implicitInputs| is not null.
 1.  Return the result of running [=measure a conversion=] with |options| and |implicitInputs|.
 
@@ -2683,7 +2685,7 @@ and [=response=] |response|, run these steps:
 1.  Let |implicitInputs| be the result of [=obtaining the implicit API inputs=] from |request|'s [=request/client=]
     with |response|'s [=response/URL=]'s [=url/origin=].
 
-1.  If |implicitInputs| is null, return.
+1.  If |implicitInputs| is null or an exception is caught, return.
 
 1.  Let |saveImpressionHeader| be the result of [=header list/get|getting=] <code>[:Save-Impression:]</code> from |response|'s [=response/header list=].
 

--- a/api.bs
+++ b/api.bs
@@ -1772,7 +1772,7 @@ and [=implicit API inputs=] |implicitInputs|:
         of invoking [=parse a site=]
         for each value in |options|.{{AttributionImpressionOptions/conversionSites}}.
     1.  If any result in |conversionSites| is failure, return
-        [=a promise rejected with=] a {{"NotAllowed"}} {{DOMException}} in |realm|.
+        [=a promise rejected with=] a {{"NotAllowedError"}} {{DOMException}} in |realm|.
     1.  If the [=list/size=] of
         |options|.{{AttributionImpressionOptions/conversionCallers}} is
         greater than the [=implementation-defined=]
@@ -1782,7 +1782,7 @@ and [=implicit API inputs=] |implicitInputs|:
         of invoking [=parse a site=]
         for each value in |options|.{{AttributionImpressionOptions/conversionCallers}}.
     1.  If any result in |conversionCallers| is failure, return
-        [=a promise rejected with=] a {{"NotAllowed"}} {{DOMException}} in |realm|.
+        [=a promise rejected with=] a {{"NotAllowedError"}} {{DOMException}} in |realm|.
 1.  Run the following steps [=in parallel=]:
      1.  Construct |impression| as a [=impression|saved impression=] comprising:
          :   [=impression/Match Value=]
@@ -2009,7 +2009,7 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
 1.  Let |impressionSites| be the [=set=] that is the result
     of invoking [=parse a site=]
     for each value in |options|.{{AttributionConversionOptions/impressionSites}}.
-1.  If any result in |impressionSites| is failure, throw a {{"NotAllowed"}} {{DOMException}}.
+1.  If any result in |impressionSites| is failure, throw a {{"NotAllowedError"}} {{DOMException}}.
 1.  If the [=list/size=] of
     |options|.{{AttributionConversionOptions/impressionCallers}} is greater than
     the [=implementation-defined=] [=maximum number of impression callers for conversion=],
@@ -2017,7 +2017,7 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
 1.  Let |impressionCallers| be the [=set=] that is the result
     of invoking [=parse a site=]
     for each value in |options|.{{AttributionConversionOptions/impressionCallers}}.
-1.  If any result in |impressionCallers| is failure, throw a {{"NotAllowed"}} {{DOMException}}.
+1.  If any result in |impressionCallers| is failure, throw a {{"NotAllowedError"}} {{DOMException}}.
 1.  Return a [=validated conversion options=] with the following fields:
     : [=validated conversion options/Aggregation Service=]
     :: |aggregationService|

--- a/api.bs
+++ b/api.bs
@@ -1078,7 +1078,10 @@ run these steps:
 
 1.  If |site| is null, return failure.
 
-1.  If |site| is "`localhost`" or if |site| [=code unit suffix|ends with=] "`.localhost`",
+1.  If |site| is "`localhost`",
+    [=code unit suffix|ends with=] "`.localhost`",
+    [=code unit prefix|starts with=] U+005B ([) (it is an IPv6 address),
+    or [=ends in a number=] (it is an IPv4 address),
     return failure.
 
 1.  Return a [=scheme-and-host=] tuple of ("`https`", |site|).
@@ -1090,9 +1093,10 @@ For example, "`extra.example.com`" is parsed as "`example.com`".
 </p>
 
 <p class=note>
-This algorithm does not accept localhost domains [[RFC6761]],
-which results in any algorithm that depends on extracting a site name
-failing when a localhost domain is mentioned
+This algorithm does not accept hosts that are
+either localhost domains [[RFC6761]] or IP addresses.
+This results in any algorithm that depends on extracting a site name
+failing when a localhost domain or IP address is mentioned
 or when the current site (top-level or framed) is a localhost domain.
 This can make using local servers for testing and development challenging.
 Implementations could offer a configuration that disables the localhost check
@@ -1768,7 +1772,7 @@ and [=implicit API inputs=] |implicitInputs|:
         of invoking [=parse a site=]
         for each value in |options|.{{AttributionImpressionOptions/conversionSites}}.
     1.  If any result in |conversionSites| is failure, return
-        [=a promise rejected with=] a {{"SyntaxError"}} {{DOMException}} in |realm|.
+        [=a promise rejected with=] a {{"NotAllowed"}} {{DOMException}} in |realm|.
     1.  If the [=list/size=] of
         |options|.{{AttributionImpressionOptions/conversionCallers}} is
         greater than the [=implementation-defined=]
@@ -1778,7 +1782,7 @@ and [=implicit API inputs=] |implicitInputs|:
         of invoking [=parse a site=]
         for each value in |options|.{{AttributionImpressionOptions/conversionCallers}}.
     1.  If any result in |conversionCallers| is failure, return
-        [=a promise rejected with=] a {{"SyntaxError"}} {{DOMException}} in |realm|.
+        [=a promise rejected with=] a {{"NotAllowed"}} {{DOMException}} in |realm|.
 1.  Run the following steps [=in parallel=]:
      1.  Construct |impression| as a [=impression|saved impression=] comprising:
          :   [=impression/Match Value=]
@@ -1838,11 +1842,12 @@ optional [=origin=] (default null):
 1.  Let |settings| be |realm|'s [=realm/settings object=].
 1.  Let |timestamp| be |settings|' [=environment settings object/current wall time=].
 1.  Let |topLevelOrigin| be |settings|' [=environment/top-level origin=].
+1.  Let |topLevelSite| be the result of [=obtain a compatible site|obtaining a compatible site=]
+    from |topLevelOrigin|.
 1.  If |origin| is null, set |origin| to |settings|' [=environment settings object/origin=].
-1.  Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from |topLevelOrigin|.
 1.  Let |intermediarySite| be:
     1.   a value of `undefined` if |origin| is [=same site=] with |topLevelOrigin|,
-    1.   otherwise, the result of [=obtain a site|obtaining a site=] from |origin|.
+    1.   otherwise, the result of [=obtain a compatible site|obtaining a compatible site=] from |origin|.
 1.  Return an [=implicit API inputs=] with the following fields:
     :   [=implicit API inputs/top-level site=]
     ::  |topLevelSite|
@@ -1852,6 +1857,27 @@ optional [=origin=] (default null):
     ::  |timestamp|
     :   [=implicit API inputs/associated document=]:
     ::  |window|'s [=associated document=]
+
+</div>
+
+<div algorithm>
+To <dfn>obtain a compatible site</dfn>,
+given [=origin=] |origin|,
+returning a [=site=]:
+
+1.  If |origin| is not a [=tuple origin=],
+    throw a  {{"NotAllowedError"}} {{DOMException}}.
+1.  Let |host| be the  [=host=] component of |origin|.
+1.  If |host| is "`localhost`",
+    if |host| [=code unit suffix|ends with=] "`.localhost`",
+    if |host| [=code unit prefix|starts with=] U+005B ([),
+    or if |host| [=ends in a number=],
+    throw a  {{"NotAllowedError"}} {{DOMException}}.
+1.  Return the result of [=obtain a site|obtaining a site=] from |origin|.
+
+
+<p class=note>See [[#site-name-algorithm]] for notes on the handling
+of localhost domains and IP address hosts.
 
 </div>
 
@@ -1983,7 +2009,7 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
 1.  Let |impressionSites| be the [=set=] that is the result
     of invoking [=parse a site=]
     for each value in |options|.{{AttributionConversionOptions/impressionSites}}.
-1.  If any result in |impressionSites| is failure, throw a {{"SyntaxError"}} {{DOMException}}.
+1.  If any result in |impressionSites| is failure, throw a {{"NotAllowed"}} {{DOMException}}.
 1.  If the [=list/size=] of
     |options|.{{AttributionConversionOptions/impressionCallers}} is greater than
     the [=implementation-defined=] [=maximum number of impression callers for conversion=],
@@ -1991,7 +2017,7 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
 1.  Let |impressionCallers| be the [=set=] that is the result
     of invoking [=parse a site=]
     for each value in |options|.{{AttributionConversionOptions/impressionCallers}}.
-1.  If any result in |impressionCallers| is failure, throw a {{"SyntaxError"}} {{DOMException}}.
+1.  If any result in |impressionCallers| is failure, throw a {{"NotAllowed"}} {{DOMException}}.
 1.  Return a [=validated conversion options=] with the following fields:
     : [=validated conversion options/Aggregation Service=]
     :: |aggregationService|
@@ -3930,6 +3956,7 @@ urlPrefix: https://html.spec.whatwg.org/; spec: html; type: dfn
     text: initiator origin; url: #document-state-initiator-origin
     text: obtain a site
     text: origin; url: #concept-origin
+    text: opaque origin; url: #concept-opaque-origin
     text: relevant settings object
     text: same site
     text: scheme; url: #concept-origin-scheme
@@ -3938,6 +3965,7 @@ urlPrefix: https://html.spec.whatwg.org/; spec: html; type: dfn
     text: top-level origin; url: #concept-environment-top-level-origin
     text: top-level traversable; url: #nav-top
     text: transient activation duration
+    text: tuple origin; url: #concept-tuple-origin
     text: iframe; url: #child-navigable
 urlPrefix: https://infra.spec.whatwg.org/; spec: infra; type: dfn;
     text: set; url: #sets
@@ -3947,6 +3975,7 @@ urlPrefix: https://storage.spec.whatwg.org/; spec: storage; type: dfn;
     text: storage key
 urlPrefix: https://url.spec.whatwg.org/; spec: url; type: dfn;
     text: domain label
+    text: ends in a number; url: #ends-in-a-number-checker
     text: host parser; url: #concept-host-parser
     text: host serializer; url: #concept-host-serializer
     text: registrable domain; url: #host-registrable-domain

--- a/api.bs
+++ b/api.bs
@@ -1872,7 +1872,7 @@ returning a [=site=]:
     if |host| [=code unit suffix|ends with=] "`.localhost`",
     if |host| [=code unit prefix|starts with=] U+005B ([),
     or if |host| [=ends in a number=],
-    throw a  {{"NotAllowedError"}} {{DOMException}}.
+    throw a {{"NotAllowedError"}} {{DOMException}}.
 1.  Return the result of [=obtain a site|obtaining a site=] from |origin|.
 
 

--- a/impl/e2e-tests/measure-conversion-errors.json
+++ b/impl/e2e-tests/measure-conversion-errors.json
@@ -147,7 +147,7 @@
       },
       "expected": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {
@@ -161,7 +161,7 @@
       },
       "expected": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {

--- a/impl/e2e-tests/measure-conversion-localhost.json
+++ b/impl/e2e-tests/measure-conversion-localhost.json
@@ -10,7 +10,7 @@
       },
       "expected": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {
@@ -23,7 +23,7 @@
       },
       "expected": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {
@@ -37,7 +37,7 @@
       },
       "expected": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {
@@ -51,7 +51,7 @@
       },
       "expected": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {
@@ -65,7 +65,85 @@
       },
       "expected": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 6,
+      "site": "127.0.0.1",
+      "event": "measureConversion",
+      "options": {
+        "aggregationService": "https://agg-service.example",
+        "histogramSize": 1
+      },
+      "expected": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 7,
+      "site": "[::1]",
+      "event": "measureConversion",
+      "options": {
+        "aggregationService": "https://agg-service.example",
+        "histogramSize": 1
+      },
+      "expected": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 8,
+      "site": "192.0.2.75",
+      "event": "measureConversion",
+      "options": {
+        "aggregationService": "https://agg-service.example",
+        "histogramSize": 1
+      },
+      "expected": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 9,
+      "site": "[3fff::100a]",
+      "event": "measureConversion",
+      "options": {
+        "aggregationService": "https://agg-service.example",
+        "histogramSize": 1
+      },
+      "expected": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 10,
+      "site": "foo.localhost.",
+      "event": "measureConversion",
+      "options": {
+        "aggregationService": "https://agg-service.example",
+        "histogramSize": 1
+      },
+      "expected": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 11,
+      "site": "0xff",
+      "event": "measureConversion",
+      "options": {
+        "aggregationService": "https://agg-service.example",
+        "histogramSize": 1
+      },
+      "expected": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
       }
     }
   ]

--- a/impl/e2e-tests/save-impression-errors.json
+++ b/impl/e2e-tests/save-impression-errors.json
@@ -30,7 +30,7 @@
       },
       "expectedError": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {
@@ -54,7 +54,7 @@
       },
       "expectedError": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {

--- a/impl/e2e-tests/save-impression-localhost.json
+++ b/impl/e2e-tests/save-impression-localhost.json
@@ -9,7 +9,7 @@
       },
       "expectedError": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {
@@ -21,7 +21,7 @@
       },
       "expectedError": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {
@@ -34,7 +34,7 @@
       },
       "expectedError": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {
@@ -47,7 +47,7 @@
       },
       "expectedError": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
       }
     },
     {
@@ -60,7 +60,79 @@
       },
       "expectedError": {
         "error": "DOMException",
-        "name": "SyntaxError"
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 6,
+      "site": "[::1]",
+      "event": "saveImpression",
+      "options": {
+        "histogramIndex": 0
+      },
+      "expectedError": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 7,
+      "site": "127.0.0.1",
+      "event": "saveImpression",
+      "options": {
+        "histogramIndex": 0
+      },
+      "expectedError": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 8,
+      "site": "192.0.2.75",
+      "event": "saveImpression",
+      "options": {
+        "histogramIndex": 0
+      },
+      "expectedError": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 9,
+      "site": "[3fff::100a]",
+      "event": "saveImpression",
+      "options": {
+        "histogramIndex": 0
+      },
+      "expectedError": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 10,
+      "site": "foo.localhost.",
+      "event": "saveImpression",
+      "options": {
+        "histogramIndex": 0
+      },
+      "expectedError": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
+      }
+    },
+    {
+      "seconds": 11,
+      "site": "0xff",
+      "event": "saveImpression",
+      "options": {
+        "histogramIndex": 0
+      },
+      "expectedError": {
+        "error": "DOMException",
+        "name": "NotAllowedError"
       }
     }
   ]

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -57,9 +57,20 @@ export function days(days: number): Temporal.Duration {
 }
 
 function parseSite(input: string): string {
+  function endsInNumber(site: string): boolean {
+    const parts = site.split(".");
+    const last = parts.pop() || parts.pop();
+    return /^(?:\d+|0x[\da-f]*)$/i.test(last);
+  }
   const site = getDomain(input, { allowPrivateDomains: true });
-  if (site === null || site === "localhost" || site.endsWith(".localhost")) {
-    throw new DOMException(`invalid site ${input}`, "SyntaxError");
+  if (
+    site === null ||
+    site === "localhost" ||
+    site.endsWith(".localhost") ||
+    site.startsWith("[") ||
+    endsInNumber(site)
+  ) {
+    throw new DOMException(`invalid site ${input}`, "NotAllowed");
   }
   return site;
 }

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -59,7 +59,7 @@ export function days(days: number): Temporal.Duration {
 function parseSite(input: string): string {
   function endsInNumber(site: string): boolean {
     const parts = site.split(".");
-    const last = parts.pop() || parts.pop();
+    const last = parts.pop() || parts.pop() || "";
     return /^(?:\d+|0x[\da-f]*)$/i.test(last);
   }
   const site = getDomain(input, { allowPrivateDomains: true });

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -70,7 +70,7 @@ function parseSite(input: string): string {
     site.startsWith("[") ||
     endsInNumber(site)
   ) {
-    throw new DOMException(`invalid site ${input}`, "NotAllowed");
+    throw new DOMException(`invalid site ${input}`, "NotAllowedError");
   }
   return site;
 }


### PR DESCRIPTION
(This sat on a branch for a whole month.  Mostly because I'm not sure if this is the right sort of check, because it expands in a very awkward way.)

I've expanded the scope of this a little to include literal IP addresses as well, after I realized that we weren't able to catch a bunch of problematic names through their use of IP addresses.  This is because of awkward things like `[::1]`, but also the wide array of ways of spelling loopback as an IPv4 address.  There are also a bunch of non-unique IP addresses that could end up being used to poison things.

The check in code is pretty small, but it's not necessarily obvious.

The knock-on effect was that it didn't make sense to use SyntaxError for the case where implicit inputs are on loopback.  I switched all of the error markings to NotAllowed instead.

Closes #456.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/pull/478.html" title="Last updated on Aug 13, 2026, 12:08 AM UTC (716acb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/478/b243f24...716acb1.html" title="Last updated on Aug 13, 2026, 12:08 AM UTC (716acb1)">Diff</a>