### PR TITLE
Fix broken tuple origin link

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -4101,7 +4101,6 @@ urlPrefix: https://html.spec.whatwg.org/; spec: html; type: dfn
     text: top-level origin; url: #concept-environment-top-level-origin
     text: top-level traversable; url: #nav-top
     text: transient activation duration
-    text: tuple origin; url: #concept-tuple-origin
     text: iframe; url: #child-navigable
 urlPrefix: https://infra.spec.whatwg.org/; spec: infra; type: dfn;
     text: set; url: #sets


### PR DESCRIPTION
Fixes #482


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/483.html" title="Last updated on Aug 19, 2026, 3:24 PM UTC (720dc73)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/483/91ef174...apasel422:720dc73.html" title="Last updated on Aug 19, 2026, 3:24 PM UTC (720dc73)">Diff</a>