### PR TITLE
It's not central DP

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -227,13 +227,27 @@ when the group that participates is larger.
 This is due to the effect of aggregation on
 the ability of sites to
 extract information about individuals from aggregates.
-This is especially true for central [[#dp|differential privacy]],
-which is the mathematical basis for the privacy design used
-in this specification.
 
-Larger cohorts of participants also produce more representative--
-and therefore more useful--
-statistics about the advertising that is being measured.
+This is especially true for the [[#dp|differential privacy]]
+model used in this specification.
+Noise is added during aggregation as a single quantity
+that is proportional to the amount that an individual contributes.
+Increased participation reduces the degree to which
+this noise affects the usefulness of the results.
+This allows the noise to be large
+relative to the values that any single person might contribute.
+
+Alternative models that rely on noise added to individual contributions
+produce more noise for the same privacy goal
+as the magnitude of noise increases with more contributions.
+The result is a worse balance of privacy and utility.
+To achieve the same utility in these systems,
+either looser privacy protections
+or measurement of significantly larger populations
+is needed.
+
+Larger cohorts of participants also produce more representative statistics,
+which are inherently more useful.
 
 If attribution is justified,
 both these factors motivate the enablement of attribution for all users.
@@ -3493,7 +3507,7 @@ which supports Laplace noise added in the aggregation.
 Supporting other noise mechanisms might require additional changes
 to how sensitivity is computed and signaled.
 
-The addition of noise in a central location,
+The addition of noise in a single location,
 as defined for any of these aggregation services,
 ensures that the total amount of noise does not increase
 as the total number of reports increases.

--- a/api.bs
+++ b/api.bs
@@ -231,7 +231,11 @@ extract information about individuals from aggregates.
 This is especially true for the [[#dp|differential privacy]]
 model used in this specification.
 Noise is added during aggregation as a single quantity
-that is proportional to the amount that an individual contributes.
+that is based on the amount of privacy budget
+that has been consumed from each individual
+that contributes to the aggregate.
+Differential privacy guarantees do not change
+based on the number of individuals who participate.
 Increased participation reduces the degree to which
 this noise affects the usefulness of the results.
 This allows the noise to be large


### PR DESCRIPTION
The noise application part is basically central, but this is misleading. The individual model we use doesn't really care about where noise is added, so we still need to be clear we are adding noise at the aggregation service.

This was hard text to touch, as it is in a tricky part of the spec.  I'd appreciate careful review.

Closes #479.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/pull/484.html" title="Last updated on Aug 28, 2026, 10:03 AM UTC (ea83220)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/484/91ef174...ea83220.html" title="Last updated on Aug 28, 2026, 10:03 AM UTC (ea83220)">Diff</a>